### PR TITLE
add link to adb.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,9 +3,9 @@
  */
 
 module.exports = exports = {
+	adb: require('./lib/adb'),
 	device: require('./lib/device'),
 	simulator: require('./lib/simulator'),
-	// symlink
-	emulator: require('./lib/simulator'),
+	emulator: require('./lib/simulator'), // symlink
 	env: require('./lib/env')
 };


### PR DESCRIPTION
lib/adb should have worked as `androidlib.adb`.
