### PR TITLE
Fix for case when stream splits log lines.

### DIFF
--- a/lib/adb.js
+++ b/lib/adb.js
@@ -6,6 +6,7 @@ var fs = require('fs'),
 	spawn = require('child_process').spawn,
 	exec = require('child_process').exec,
 	env = require('./env'),
+	logcat = require('adbkit-logcat'),
 	lastOptions;
 
 exports.launch = launch;
@@ -32,7 +33,7 @@ function tailLog(options,pid,callback) {
 	var android = env.find(options,callback),
 		adb = android && path.join(android.sdkPath,'platform-tools','adb'),
 		target = options.target === 'device' ? '-d' : '-e',
-		child = android && spawn(adb,[target,'logcat']),
+		child = android && spawn(adb,[target,'logcat', '-B']),
 		moveAhead = String(pid).length + 3,
 		logger = options.logger,
 		auto_exit = options.auto_exit,
@@ -50,50 +51,42 @@ function tailLog(options,pid,callback) {
 		}
 	}
 
-	child.stdout.on('data',function(buf){
-		buf = String(buf);
-		buf.split('\n').forEach(function(line){
-			if (!pid) {
-				var m = searchRegex.exec(line);
-				if (m) {
-					pid = m[1];
-					moveAhead = pid.length + 3;
-				}
-				return;
-			}
-			var idx = line.indexOf(pid+'): ');
-			if (idx<0) return;
-			var msg = filterLog(line.substring(idx+moveAhead).trim()),
-				label = line.substring(0,2);
-			if (!msg) return;
-			if (auto_exit && msg==='TI_EXIT') {
+	reader = logcat.readStream(child.stdout);
+	reader.on('entry', function(entry) {
+		if(pid == entry.pid) {
+			if (auto_exit && entry.message==='TI_EXIT') {
 				return finish();
 			}
-			switch (label) {
-				case 'I/':
-					logger('info',msg);
+			switch (entry.priority) {
+				case logcat.Priority.INFO:
+					logger('info',entry.message);
 					break;
-				case 'D/':
+				case logcat.Priority.DEBUG:
 					// filter out some android low-level stuff
-					if (/^(pt_debug|ion)\s*\:/.test(msg) || /^, tls=0x/.test(msg)) {
-						logger('trace',msg);
+					if (/^(pt_debug|ion)\s*\:/.test(entry.message) || /^, tls=0x/.test(entry.message)) {
+						logger('trace',entry.message);
 					}
 					else {
-						logger('debug',msg);
+						logger('debug',entry.message);
 					}
 					break;
-				case 'W/':
-					logger('warn',msg);
+				case logcat.Priority.WARN:
+					logger('warn',entry.message);
 					break;
-				case 'E/':
-				case 'F/':
-					logger('error',msg);
+				case logcat.Priority.ERROR:
+				case logcat.Priority.FATAL:
+					logger('error',entry.message);
 					break;
 			}
-		});
+	  }
+
 	});
-	child.on('error',finish);
-	child.on('close',finish);
+	reader.on('error', function(err) {
+		finish
+	});
+	reader.on('finish', function(err) {
+		finish
+	});
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "androidlib",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Android Utility Library",
   "main": "index.js",
   "scripts": {
@@ -20,6 +20,7 @@
     "url": "https://github.com/appcelerator/androidlib/issues"
   },
   "dependencies": {
+    "adbkit-logcat": "~1.0.3",
     "async": "~0.9.0",
     "colors": "~0.6.2",
     "commander": "~2.2.0",


### PR DESCRIPTION
This bug causes some parts of the lines to vanish after the split.

Example would be in this scenario:
Data callback 1:
```
I/TiAPI   ( 2856):  !TEST_RESULTS_START!
I/TiAPI   ( 2856): {
I/TiAPI   ( 2856): 	"date": "2015-01-23T08:04:59.765Z",
I/TiAPI   ( 2856): 	"results": [
I/TiAPI   ( 2856): 		{
I/TiAPI   ( 2856): 			"state": "passed",
I/TiAPI   ( 2856): 			"duration": 1040,
I/TiAPI   ( 2856): 			"suite": "buffer",
I/TiAPI   ( 2856): 			"title": "testAPI"
I/TiAPI   ( 2856): 		},
I/TiAPI   ( 2856): 		{
I/TiAPI   ( 2856): 			"state": "passed",
I/TiAPI   ( 2856): 			"duration": 9660,
I/TiAPI   ( 2856): 			"suite": "buffer",
I/TiAPI   ( 2856): 			"title": "testLength"
I/TiAPI   ( 2856): 		},
I/TiAPI   ( 2856): 		{
I/TiAPI   ( 2856): 			"state": "passed",
I/TiAPI   ( 2856): 			"duration": 98065,
I/TiAPI   ( 2856): 			"suite": "buffer",
I/TiAPI   ( 2856): 			"title": "testAppend"
I/TiAPI   ( 2856): 		},
I/TiAPI   ( 2856): 		{
I/TiAPI   ( 2856): 			"state": "passed",
I/TiAPI   ( 2856): 			"duration": 58124,
I/TiAPI   ( 2856): 			"suite": "buffer",
I/TiAPI   ( 2856): 			"title": "testInsert"
I/TiAPI   ( 2856): 		},
I/TiAPI   ( 2856): 		{
I/TiAPI   ( 2856): 			"state": "passed",
I/TiAPI   ( 2856): 			"duration": 9049,
I/TiAPI   ( 2856): 			"suite": "buffer",
I/TiAPI   ( 2856): 			"title": "testInsertBlogExample"
I/TiAPI   ( 2856): 		},
I/TiAPI   ( 2856): 		{
I/TiAPI   ( 2856): 			"state": "passed",
I/TiAPI   ( 2856): 			"duration": 64461,
I/TiAPI   ( 2856): 			"suite": "buffer",
I/TiAPI   ( 2856): 			"title": "testCopy"
I/TiAPI   ( 2856): 		},
I/TiAPI   ( 2856): 		{
I/TiAPI   ( 2856): 			"state": "failed",
I/TiAPI   ( 2856): 			"duration": 3481,
I/TiAPI   ( 2856): 			"suite": "buffer",
I/TiAPI   ( 2856): 			"title": "testClone",
I/TiAPI   ( 2856): 			"error": {
I/TiAPI   ( 2856): 				"name": "AssertionError",
I/TiAPI   ( 2856): 				"actual": {
I/TiAPI   ( 2856): 					"length": 20,
I/TiAPI   ( 2856): 					"bubbleParent": true,
I/TiAPI   ( 2856): 					"apiName": "Ti.Buffer"
I/TiAPI   ( 2856): 				},
I/TiAPI   ( 2856): 				"expected": {
I/TiAPI   ( 2856): 					"length": 20,
I/TiAPI   ( 2856): 					"bubbleParent": true,
I/TiAPI   ( 2856): 					"byteOrder": 1,
I/TiAPI   ( 2856): 					"apiName": "Ti.Buffer"
I/TiAPI   ( 2856): 				},
I/TiAPI   ( 2856): 				"operator": "to equal",
I/TiAPI   ( 2856): 				"message": "expected { _hasJavaListener: undefined,\n length: 20,\n bubbleParent: true,\n byteOrder: undefined,\n type: undefined,\n value: undefined,\n apiName: 'Ti.Buffer' } to equal { _hasJavaListener: undefined,\n length: 20,\n bubbleParent: true,\n byteOrder: 1,\n type: undefined,\n value: undefined,\n apiName: 'Ti.Buffer' }",
I/TiAPI   ( 2856): 				"generatedMessage": true,
I/TiAPI   ( 2856): 				"showDiff": true
I/TiAPI   ( 2856): 			}
I/TiAPI   ( 2856): 		},
I/TiAPI   ( 2856): 		{
I/TiAPI   ( 2856): 			"state": "passed",
I/TiAPI   ( 2856): 			"duration": 92516,
I/TiAPI   ( 2856): 			"suite": "buffer",
I/TiAPI   ( 2856): 			"title": "testFill"
I/TiAPI   ( 2856): 		},
I/TiAPI   ( 2856): 		{
I/TiAPI   ( 2856): 			"state": "passed",
I/TiAPI   ( 2856): 			"duration": 1110,
I/TiAPI   ( 2856): 			"suite": "buffer",
I/TiAPI   ( 2856): 			"title": "testClear"
I/TiAPI   ( 2856): 		},
I/TiAPI   ( 2856): 		{
I/TiAPI   ( 2856): 			"state": "passed",
I/TiAPI   ( 2856): 			"duration": 528,
I/TiAPI   ( 2856): 			"suite": "buffer",
I/TiAPI   ( 2856): 			"title": "testRelease"
I/TiAPI   ( 2856): 		},
I/TiAPI   ( 2856): 		{
I/TiAPI   ( 2856): 			"state": "passed",
I/TiAPI   ( 2856): 			"duration": 18048,
I/TiAPI   ( 2856): 			"suite": "buffer",
I/TiAPI   ( 2856): 			"title": "testToStringAndBlob"
I/TiAPI   ( 2856): 		},
I/TiAPI   ( 2856): 		{
I/TiAPI   ( 2856): 			"state": "passed",
I/TiAPI   ( 2856): 			"duration": 1223,
I/TiAPI   ( 2856): 			"suite": "buffer",
I/TiAPI   ( 2856): 			"title": "testAutoEncode"
I/TiAPI   ( 2856): 		}
I/TiAPI   ( 2856): 	],
I/TiAPI   ( 2856): 	"platform": {
I/TiAPI   ( 2856): 		"ostype": "32bit",
I/TiAPI   ( 2856): 		"name": "android",
I/TiAPI   ( 2856): 		"osname": "android",
I/TiAPI   ( 2856): 		"version": "4.4.4",
I/TiAPI   ( 2856): 		"ad
```
Data callback 2
```
dress": "10.0.3.15",
I/TiAPI   ( 2856): 		"macaddress": "08:00:27:e5:f1:d0",
I/TiAPI   ( 2856): 		"architecture": "Unknown",
I/TiAPI   ( 2856): 		"availableMemory": 415984,
I/TiAPI   ( 2856): 		"manufacturer": "Genymotion",
I/TiAPI   ( 2856): 		"model": "Google Nexus 5 - 4.4.4 - API 19 - 1080x1920"
I/TiAPI   ( 2856): 	},
I/TiAPI   ( 2856): 	"displayCaps": {
I/TiAPI   ( 2856): 		"density": "xxhigh",
I/TiAPI   ( 2856): 		"dpi": 480,
I/TiAPI   ( 2856): 		"platformHeight": 1776,
I/TiAPI   ( 2856): 		"platformWidth": 1080,
I/TiAPI   ( 2856): 		"xdpi": 480,
I/TiAPI   ( 2856): 		"ydpi": 480
I/TiAPI   ( 2856): 	},
I/TiAPI   ( 2856): 	"build": {
I/TiAPI   ( 2856): 		"date": "2015/01/12 15:33",
I/TiAPI   ( 2856): 		"git": "0014f83",
I/TiAPI   ( 2856): 		"version": "3.5.0"
I/TiAPI   ( 2856): 	}
I/TiAPI   ( 2856): }
I/TiAPI   ( 2856): !TEST_RESULTS_STOP!
```
The last part of the address,  ```dress": "10.0.3.15",``` would cause the original code to return, hence that part is not sent out to the logger at all. This causes the json to be incomplete and causing errors.